### PR TITLE
Add version for Umbraco 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ Render a `<picture>` tag with a set of `<source>` children. The `sources` param 
 @{
 	var sources = new List<PictureSource>();
 	
-	sources.Add(new PictureSource { Media = "max375", Crop = "Portrait", Width = "400" });
-	sources.Add(new PictureSource { Media = "min376", Crop = "Landscape", Width = "800" });
-	sources.Add(new PictureSource { Media = "min1200", Crop = "Landscape", Width = "1400" });
+	sources.Add(new PictureSource { Media = "max375", Crop = "Portrait", Width = 400 });
+	sources.Add(new PictureSource { Media = "min376", Crop = "Landscape", Width = 800 });
+	sources.Add(new PictureSource { Media = "min1200", Crop = "Landscape", Width = 1400 });
 	// Specify Media as `""` or `null` for the default to load in the `<img>` tag
-	sources.Add(new PictureSource { Media = "", Crop = "Landscape", Width = "600" });
+	sources.Add(new PictureSource { Media = "", Crop = "Landscape", Width = 600 });
 }
 
 @MediaHelper.RenderPicture(Model.PageImage, sources)

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -81,16 +81,6 @@ namespace Vokseverk {
 			return result;
 		}
 		
-		public static HtmlString RenderMedia(object mediaId, string crop, int width) {
-			// TODO: Find new way of getting an `UmbracoHelper` ...
-			return new HtmlString("Not implemented yet");
-		}
-
-		public static HtmlString RenderMedia(object mediaId, int width) {
-			// TODO: Find new way of getting an `UmbracoHelper` ...
-			return new HtmlString("Not implemented yet");
-		}
-		
 		/// <summary>
 		/// Render an img tag with srcset and src attributes for a media item,
 		/// using the specified crop and output width.

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -22,6 +22,7 @@ namespace Vokseverk {
 	public class MediaSize {
 		public int Width { get; set; }
 		public int Height { get; set; }
+		public decimal Ratio { get; set; }
 	}
 	
 	public class MediaHelper {
@@ -70,12 +71,17 @@ namespace Vokseverk {
 		/// Retrieves the width and height of a media item.
 		/// Returns 0 for both if either of the properties are missing.
 		/// </summary>
-		public static MediaSize GetMediaSize(IPublishedContent media) {
-			var result = new MediaSize { Width = 0, Height = 0 };
+		public static MediaSize GetMediaSize(IPublishedContent media, int newWidth = 0) {
+			var result = new MediaSize { Width = 0, Height = 0, Ratio = 1.0M };
 			
 			if (media.HasProperty("UmbracoWidth") && media.HasProperty("UmbracoHeight")) {
-				result.Width = media.Value<int>("UmbracoWidth");
-				result.Height = media.Value<int>("UmbracoHeight");
+				var mediaWidth = media.Value<int>("UmbracoWidth");
+				var mediaHeight = media.Value<int>("UmbracoHeight");
+				var mediaRatio = Decimal.Divide(mediaHeight, mediaWidth);
+				
+				result.Width = newWidth > 0 ? newWidth : mediaWidth;
+				result.Height = newWidth > 0 ? (int)(mediaWidth * mediaRatio) : mediaHeight;
+				result.Ratio = mediaRatio;
 			}
 			
 			return result;

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -80,7 +80,7 @@ namespace Vokseverk {
 				var mediaRatio = Decimal.Divide(mediaHeight, mediaWidth);
 				
 				result.Width = newWidth > 0 ? newWidth : mediaWidth;
-				result.Height = newWidth > 0 ? (int)(mediaWidth * mediaRatio) : mediaHeight;
+				result.Height = newWidth > 0 ? (int)(newWidth * mediaRatio) : mediaHeight;
 				result.Ratio = mediaRatio;
 			}
 			

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -118,14 +118,14 @@ namespace Vokseverk {
 			
 			try {
 				if (image != null) {
-					var url = GetMediaUrl(image);
-					var combiner = url.Contains("?") ? "&" : "?";
-					var size1x = string.Format("{0}{1}width={2}&quality=70", url, combiner, width);
-					var size2x = string.Format("{0}{1}width={2}&quality=40", url, combiner, width * 2);
+					var url = image.Url;
+					var dimensions = GetMediaSize(image, width);
+					var size1x = image.GetCropUrl(width: width, quality: 70);
+					var size2x = image.GetCropUrl(width: width * 2, quality: 40);
 					
-					var extension = image.Value<string>("umbracoExtension");
+					var extension = image.Value<string>("UmbracoExtension");
 					imageTag = extension == "gif"
-						? GetOutputTag(url, image.Name)
+						? GetOutputTag(url, image.Name) // Don't resize GIFs
 						: GetOutputTag(size1x, size2x, image.Name);
 				}
 			} catch (Exception ex) {

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -19,6 +19,11 @@ namespace Vokseverk {
 		public int Width { get; set; }
 	}
 	
+	public class MediaSize {
+		public int Width { get; set; }
+		public int Height { get; set; }
+	}
+	
 	public class MediaHelper {
 				
 		/// <summary>
@@ -61,6 +66,20 @@ namespace Vokseverk {
 			return new HtmlString(html);
 		}
 		
+		/// <summary>
+		/// Retrieves the width and height of a media item.
+		/// Returns 0 for both if either of the properties are missing.
+		/// </summary>
+		public static MediaSize GetMediaSize(IPublishedContent media) {
+			var result = new MediaSize { Width = 0, Height = 0 };
+			
+			if (media.HasProperty("UmbracoWidth") && media.HasProperty("UmbracoHeight")) {
+				result.Width = media.Value<int>("UmbracoWidth");
+				result.Height = media.Value<int>("UmbracoHeight");
+			}
+			
+			return result;
+		}
 		
 		public static HtmlString RenderMedia(object mediaId, string crop, int width) {
 			// TODO: Find new way of getting an `UmbracoHelper` ...

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -218,13 +218,22 @@ namespace Vokseverk {
 
 		#region Private
 		
+		// Actual <img> tag rendering
 		private static string GetOutputTag(string image, string altText) {
 			return string.Format("<img src=\"{0}\" alt=\"{1}\" />", image, altText);
 		}
+		private static string GetOutputTag(string image, string altText, MediaSize sizes) {
+			return string.Format("<img src=\"{0}\" width=\"{2}\" height=\"{3}\" alt=\"{1}\" />", image, altText, sizes.Width, sizes.Height);
+		}
 		
+		// Overloads for a retina-ready image (srcset w/ 2x)
 		private static string GetOutputTag(string size1x, string size2x, string altText) {
 			return string.Format("<img srcset=\"{0} 2x\" src=\"{1}\" alt=\"{2}\" />", size2x, size1x, altText);
 		}
+		private static string GetOutputTag(string size1x, string size2x, string altText, MediaSize sizes) {
+			return string.Format("<img srcset=\"{0} 2x\" src=\"{1}\" width=\"{3}\" height=\"{4}\" alt=\"{2}\" />", size2x, size1x, altText, sizes.Width, sizes.Height);
+		}
+		
 		
 		private static string GetSourceTag(string size1x, string size2x, string media = "") {
 			var outputTag = "";

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -125,8 +125,8 @@ namespace Vokseverk {
 					
 					var extension = image.Value<string>("UmbracoExtension");
 					imageTag = extension == "gif"
-						? GetOutputTag(url, image.Name) // Don't resize GIFs
-						: GetOutputTag(size1x, size2x, image.Name);
+						? GetOutputTag(url, image.Name, dimensions) // Don't resize GIFs
+						: GetOutputTag(size1x, size2x, image.Name, dimensions);
 				}
 			} catch (Exception ex) {
 				imageTag = GetOutputTag("/media/blank.png", string.Format("Could not find media item. ({0})", ex.Message));

--- a/src/Vokseverk.MediaHelper.cs
+++ b/src/Vokseverk.MediaHelper.cs
@@ -1,6 +1,7 @@
-using Umbraco;
+﻿using Umbraco;
 using Umbraco.Web;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
 using System;
 using System.Collections.Generic;
 using System.Web;
@@ -19,28 +20,10 @@ namespace Vokseverk {
 	}
 	
 	public class MediaHelper {
-		private readonly static UmbracoHelper umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-		
+				
 		/// <summary>
-		/// Render a <c>picture</c> tag with specified source elements
+		/// Render a `picture` tag with specified source elements
 		/// </summary>
-		/// <param name="mediaItem">The media item to render</param>
-		/// <param name="sources">A <c>List</c> of <seealso cref="PictureSource" /> definitions to use as <c>source</c> elements</param>
-		/// <param name="cssClass">An optional CSS classname to put on the <c>picture</c> tag</param>
-		/// <example>
-		/// <code>
-		/// @{
-		///   var sources = new List<PictureSource>();
-		///   
-		///   sources.Add(new PictureSource { Media = "max375", Crop = "Portrait", Width = "400" });
-		///   sources.Add(new PictureSource { Media = "min376", Crop = "Landscape", Width = "800" });
-		///   sources.Add(new PictureSource { Media = "min1200", Crop = "Landscape", Width = "1600" });
-		///   // Specify `""` or `null` for the default to load in the `<img>` tag
-		///   sources.Add(new PictureSource { Media = "", Crop = "Landscape", Width = "600" });
-		/// }
-		/// @MediaHelper.RenderPicture(Model.PageImage, sources)
-		/// </code>
-		/// </example>
 		public static HtmlString RenderPicture(IPublishedContent mediaItem, List<PictureSource> sources, string cssClass = "") {
 			var html = string.Format("<picture class=\"{0}\">", cssClass);
 			html = html.Replace(" class=\"\"", "");
@@ -51,7 +34,12 @@ namespace Vokseverk {
 					var mediaURL1x = mediaItem.GetCropUrl(cropAlias: source.Crop, width: source.Width, quality: 70);
 					var mediaURL2x = mediaItem.GetCropUrl(cropAlias: source.Crop, width: source.Width * 2, quality: 40);
 
-					if (string.IsNullOrEmpty(source.Media)) {
+					if (source.Media == "2x") {
+						// Special case for rendering a single image for 1x and 2x using a `<picture<` tag
+						html += GetSourceTag(mediaURL1x, mediaURL2x, mediaAttr);
+						html += GetOutputTag(mediaURL1x, mediaItem.Name);
+					}
+					else if (string.IsNullOrEmpty(source.Media)) {
 						// Add required `<img>` tag
 						html += GetOutputTag(mediaURL1x, mediaItem.Name);
 					} else {
@@ -67,83 +55,105 @@ namespace Vokseverk {
 				html += "<p style=\"color:red;font-weight:bold;\">Error: " + ex.Message + "</p>";
 			}
 			
+			// Return a HtmlString
 			html += "</picture>";
 			
 			return new HtmlString(html);
 		}
 		
 		
+		public static HtmlString RenderMedia(object mediaId, string crop, int width) {
+			// TODO: Find new way of getting an `UmbracoHelper` ...
+			return new HtmlString("Not implemented yet");
+		}
+
+		public static HtmlString RenderMedia(object mediaId, int width) {
+			// TODO: Find new way of getting an `UmbracoHelper` ...
+			return new HtmlString("Not implemented yet");
+		}
+		
 		/// <summary>
-		/// Render an <c>img</c> tag with <c>srcset</c> and <c>src</c> attributes for a media item,
+		/// Render an img tag with srcset and src attributes for a media item,
 		/// using the specified crop and output width.
 		/// </summary>
-		public static HtmlString RenderMedia(object mediaId, string crop, int width) {
+		public static HtmlString RenderMedia(IPublishedContent image, string crop, int width) {
 			string imageTag = "";
 			
 			try {
-				var media = umbracoHelper.TypedMedia(mediaId);
-				if (media != null) {
-					var crop1x = media.GetCropUrl(cropAlias: crop, width: width, quality: 70);
-					var crop2x = media.GetCropUrl(cropAlias: crop, width: width * 2, quality: 40);
+				if (image != null) {
+					var crop1x = image.GetCropUrl(cropAlias: crop, width: width, quality: 70);
+					var crop2x = image.GetCropUrl(cropAlias: crop, width: width * 2, quality: 40);
 					
-					imageTag = GetOutputTag(crop1x, crop2x, media.Name);
+					imageTag = GetOutputTag(crop1x, crop2x, image.Name);
 				}
 			} catch (Exception ex) {
 				imageTag = GetOutputTag("/media/blank.png", string.Format("Did not find the media item. ({0})", ex.Message));
 			}
 			
 			return new HtmlString(imageTag);
+			
 		}
 
 		/// <summary>
-		/// Overload to render an <c>img</c> tag with <c>srcset</c> and <c>src</c> attributes for a media item,
-		/// using the specified output width (as the 1x width).
+		/// Render an img tag with srcset and src attributes for a media item,
+		/// using the specified output width.
 		/// </summary>
-		public static HtmlString RenderMedia(object mediaId, int width) {
+		public static HtmlString RenderMedia(IPublishedContent image, int width) {
 			string imageTag = "";
 			
 			try {
-				var media = umbracoHelper.TypedMedia(mediaId);
-				if (media != null) {
-					// Need to use `Url` instead of `GetCropUrl()`
-					// to not get a crop. Then build manually...
-					var url = media.Url;
+				if (image != null) {
+					var url = GetMediaUrl(image);
 					var combiner = url.Contains("?") ? "&" : "?";
 					var size1x = string.Format("{0}{1}width={2}&quality=70", url, combiner, width);
 					var size2x = string.Format("{0}{1}width={2}&quality=40", url, combiner, width * 2);
 					
-					var extension = media.GetPropertyValue<string>("umbracoExtension");
+					var extension = image.Value<string>("umbracoExtension");
 					imageTag = extension == "gif"
-						? GetOutputTag(url, media.Name)
-						: GetOutputTag(size1x, size2x, media.Name);
+						? GetOutputTag(url, image.Name)
+						: GetOutputTag(size1x, size2x, image.Name);
 				}
 			} catch (Exception ex) {
 				imageTag = GetOutputTag("/media/blank.png", string.Format("Could not find media item. ({0})", ex.Message));
 			}
 			
 			return new HtmlString(imageTag);
-		}
-		
-		// Overloads for rendering media when the image is already an IPublishedContent
-		public static HtmlString RenderMedia(IPublishedContent image, string crop, int width) {
-			return RenderMedia(image.Id, crop, width);
-		}
-
-		public static HtmlString RenderMedia(IPublishedContent image, int width) {
-			return RenderMedia(image.Id, width);
+			
 		}
 		
 		/// <summary>
-		/// Get the URL for a placeholder image of the specified size
+		/// Render the entire media inside a box defined by <paramref name="size" />
 		/// </summary>
-		/// <param name="size">A string of the form <c>800x600</c> to define the width and height of the placeholder</param>
+		/// <param name="size">A string in the form {width}x{height}, e.g.: 300x200</param>
+		public static HtmlString RenderMedia(IPublishedContent image, string size) {
+			string imageTag = "";
+			string mediaUrl = GetMediaUrl(image);
+			int w = 0;
+			int h = 0;
+			
+			if (mediaUrl.Contains("GetMediaUrl")) {
+				imageTag = string.Format("<!-- {0} -->", mediaUrl);
+			} else {
+				var dimensions = size.Split('x');
+
+				if (Int32.TryParse(dimensions[0], out w) && Int32.TryParse(dimensions[1], out h)) {
+					var size1x = string.Format("{0}?width={1}&height={2}&quality=70", mediaUrl, w, h);
+					var size2x = string.Format("{0}?width={1}&height={2}&quality=40", mediaUrl, w * 2, h * 2);
+				
+					imageTag = GetOutputTag(size1x, size2x, image.Name);
+				}
+				
+			}
+			
+			return new HtmlString(imageTag);
+		}
+		
 		public static string GetPlaceholderUrl(string size) {
 			return string.Format("//placehold.it/{0}", size);
 		}
 		
-		public static string GetMediaUrl(object mediaId) {
+		public static string GetMediaUrl(IPublishedContent media) {
 			try {
-				var media = umbracoHelper.TypedMedia(mediaId);
 				if (media != null) {
 					return media.Url;
 				} else {
@@ -154,6 +164,43 @@ namespace Vokseverk {
 			}
 		}
 		
+		/// <summary>
+		/// Single point of getting a URL for a mediaitem
+		/// </summary>
+		public static string GetCropUrl(IPublishedContent mediaItem, string crop, int width, int quality = 70) {
+			string outputUrl = "";
+			
+			try {
+				if (mediaItem != null) {
+					outputUrl = mediaItem.GetCropUrl(cropAlias: crop, width: width, quality: quality);
+				}
+			} catch (Exception ex) {
+				outputUrl = "(error)";
+			}
+			
+			return outputUrl;
+		}
+		
+		public static HtmlString RenderSVG(string reference, int width = 70, int height = 70) {
+			string name = "";
+			string svgTag = "";
+			string prefix = "icon-";
+			
+			if (reference.EndsWith(".svg")) {
+				var nameRE = new Regex(@"^.*?([^\/]+?)\.svg$");
+				var match = nameRE.Match(reference);
+				if (match.Success) {
+					name = match.Groups[1].Value;
+				}
+			} else {
+				// Assume a simple "chat" or "rollerblade-yellow" name
+				name = prefix + reference;
+			}
+			svgTag = string.Format("<svg class=\"icon {0}\" viewBox=\"0 0 {1} {2}\" width=\"{1}\"><use xlink:href=\"#{0}\" /></svg>", name, width, height);
+
+			return new HtmlString(svgTag);
+		}
+
 		#region Private
 		
 		private static string GetOutputTag(string image, string altText) {
@@ -164,8 +211,16 @@ namespace Vokseverk {
 			return string.Format("<img srcset=\"{0} 2x\" src=\"{1}\" alt=\"{2}\" />", size2x, size1x, altText);
 		}
 		
-		private static string GetSourceTag(string size1x, string size2x, string media) {
-			return string.Format("<source media=\"{2}\" srcset=\"{0} 2x,{1}\" />", size2x, size1x, media);
+		private static string GetSourceTag(string size1x, string size2x, string media = "") {
+			var outputTag = "";
+			
+			if (media == "") {
+				outputTag = string.Format("<source srcset=\"{0} 2x,{1}\" />", size2x, size1x);
+			} else {
+				outputTag = string.Format("<source media=\"{2}\" srcset=\"{0} 2x,{1}\" />", size2x, size1x, media);
+			}
+			
+			return outputTag;
 		}
 		
 		#endregion


### PR DESCRIPTION
This is the first version that works with Umbraco 8.

This also enables rendering the width and height attributes so the browser knows how much space to clear for the image to fill when loaded.

Fixes #3 